### PR TITLE
Add option pure_scp to SshOpts to allow scp to/from non unix systems

### DIFF
--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -105,6 +105,9 @@ pub struct SshOpts {
     parse_rules: ParseRule,
     /// Ssh agent configuration for authentication
     ssh_agent_identity: Option<SshAgentIdentity>,
+    /// do not use any shell command when doing SCP operations
+    /// to make sure to be compatible with non unix systems
+    pure_scp: bool,
 }
 
 impl SshOpts {
@@ -125,6 +128,7 @@ impl SshOpts {
             methods: Vec::default(),
             parse_rules: ParseRule::STRICT,
             ssh_agent_identity: None,
+            pure_scp: false,
         }
     }
 
@@ -163,6 +167,13 @@ impl SshOpts {
     /// Otherwise the provided public key will be used
     pub fn ssh_agent_identity(mut self, ssh_agent_identity: Option<SshAgentIdentity>) -> Self {
         self.ssh_agent_identity = ssh_agent_identity;
+        self
+    }
+
+    /// do not use any shell command when doing SCP operations
+    /// to make sure to be compatible with non unix systems
+    pub fn pure_scp(mut self, pure_scp: bool) -> Self {
+        self.pure_scp = pure_scp;
         self
     }
 

--- a/src/ssh/scp.rs
+++ b/src/ssh/scp.rs
@@ -242,11 +242,13 @@ where
             "Connection established: {}",
             banner.as_deref().unwrap_or("")
         );
-        // Get working directory
-        debug!("Getting working directory...");
-        self.wrkdir = session
-            .cmd("pwd")
-            .map(|(_rc, output)| PathBuf::from(output.as_str().trim()))?;
+        if !self.opts.pure_scp {
+            // Get working directory
+            debug!("Getting working directory...");
+            self.wrkdir = session
+                .cmd("pwd")
+                .map(|(_rc, output)| PathBuf::from(output.as_str().trim()))?;
+        }
         // Set session
         self.session = Some(session);
         info!(
@@ -667,9 +669,11 @@ where
         self.check_connection()?;
         let path = path_utils::absolutize(self.wrkdir.as_path(), path);
         debug!("Opening file {} for read", path.display());
-        // check if file exists
-        if !self.exists(path.as_path()).ok().unwrap_or(false) {
-            return Err(RemoteError::new(RemoteErrorType::NoSuchFileOrDirectory));
+        if !self.opts.pure_scp {
+            // check if file exists
+            if !self.exists(path.as_path()).ok().unwrap_or(false) {
+                return Err(RemoteError::new(RemoteErrorType::NoSuchFileOrDirectory));
+            }
         }
         trace!("blocked channel");
         match self.session.as_mut().unwrap().scp_recv(path.as_path()) {


### PR DESCRIPTION
# Add option pure_scp to SshOpts to allow scp to/from non unix systems



## Description

Connecting to non unix system via scp fails, because pwd and ls are not available. The pure_scp option just disable anything and does only the pure scp transfer

## Type of change

Please select relevant options.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ X] My code follows the contribution guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes generate no new warnings
- [ X] I formatted the code with `cargo fmt`
- [ X] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
