### PR TITLE
fix(scp): use stat epoch for mtime instead of TZ-ambiguous ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.8.3
+
+Released on 2026-04-18
+
+### Fixed
+
+- **scp:** mtime wrongly treated as UTC; use `stat` for timezone-free epoch
+  > SCP listings parsed the `ls -l` timestamp as if it were UTC, so clients
+  > rendering via `DateTime<Local>` displayed a UTC wall clock instead of
+  > the server's local time. Override the `ls`-parsed mtime with the Unix
+  > epoch obtained from `stat -c %Y` (GNU) or `stat -f %m` (BSD), probed
+  > once per session and cached. Falls back to the `ls` parser on hosts
+  > where neither flavor is available. Closes
+  > [veeso/termscp#416](https://github.com/veeso/termscp/issues/416).
+
 ## 0.8.2
 
 Released on 2026-03-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remotefs-ssh"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 description = "remotefs SSH client library"

--- a/src/ssh/scp.rs
+++ b/src/ssh/scp.rs
@@ -2,6 +2,7 @@
 //!
 //! Scp remote fs implementation
 
+use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -22,6 +23,22 @@ static LS_RE: Lazy<Regex> = lazy_regex!(
     r#"^(?<sym_dir>[\-ld])(?<pex>[\-rwxsStT]{9})(?<sec_ctx>\.|\+|\@)?\s+(?<n_links>\d+)\s+(?<uid>.+)\s+(?<gid>.+)\s+(?<size>\d+)\s+(?<date_time>\w{3}\s+\d{1,2}\s+(?:\d{1,2}:\d{1,2}|\d{4}))\s+(?<name>.+)$"#
 );
 
+/// Which `stat(1)` format flags the remote host accepts.
+///
+/// `ls -l` prints times in the server's local timezone with no offset, so we
+/// use `stat` to get a timezone-free Unix epoch. The CLI flags differ between
+/// GNU coreutils and BSD `stat`, so we probe once per session and cache the
+/// result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatFlavor {
+    /// GNU coreutils: `stat -c '<fmt>'`.
+    Gnu,
+    /// BSD / macOS: `stat -f '<fmt>'`.
+    Bsd,
+    /// Neither flavor is available; fall back to parsing `ls` output.
+    Unsupported,
+}
+
 /// SCP "filesystem" client
 pub struct ScpFs<S>
 where
@@ -30,6 +47,8 @@ where
     session: Option<S>,
     wrkdir: PathBuf,
     opts: SshOpts,
+    /// Cached `stat(1)` flavor for the remote host; probed lazily on first use.
+    stat_flavor: Option<StatFlavor>,
 }
 
 #[cfg(feature = "libssh2")]
@@ -41,6 +60,7 @@ impl ScpFs<super::backend::LibSsh2Session> {
             session: None,
             wrkdir: PathBuf::from("/"),
             opts,
+            stat_flavor: None,
         }
     }
 }
@@ -54,6 +74,7 @@ impl ScpFs<super::backend::LibSshSession> {
             session: None,
             wrkdir: PathBuf::from("/"),
             opts,
+            stat_flavor: None,
         }
     }
 }
@@ -71,6 +92,7 @@ where
             session: None,
             wrkdir: PathBuf::from("/"),
             opts,
+            stat_flavor: None,
         }
     }
 }
@@ -244,6 +266,79 @@ where
             Err(err) => Err(RemoteError::new_ex(RemoteErrorType::StatFailed, err)),
         }
     }
+
+    /// Detect which `stat(1)` flavor the remote host supports.
+    ///
+    /// Probes GNU first (`stat --version`, which BSD rejects) then BSD (`stat
+    /// -f %m /`). The result is cached on the session; callers pay at most
+    /// one extra roundtrip per connection. Returns
+    /// [`StatFlavor::Unsupported`] when neither flavor works so the caller
+    /// can fall back to the `ls`-based parser.
+    fn stat_flavor(&mut self) -> StatFlavor {
+        if let Some(flavor) = self.stat_flavor {
+            return flavor;
+        }
+        let session = self.session.as_mut().unwrap();
+        let flavor = match session.cmd("stat --version >/dev/null 2>&1") {
+            Ok((0, _)) => StatFlavor::Gnu,
+            _ => match session.cmd("stat -f %m / >/dev/null 2>&1") {
+                Ok((0, _)) => StatFlavor::Bsd,
+                _ => StatFlavor::Unsupported,
+            },
+        };
+        trace!("Detected remote stat flavor: {flavor:?}");
+        self.stat_flavor = Some(flavor);
+        flavor
+    }
+
+    /// Fetch the Unix epoch mtime of a single `path` via `stat`.
+    ///
+    /// Returns [`None`] when the remote host exposes neither GNU nor BSD
+    /// `stat`, or when the command fails.
+    fn mtime_epoch(&mut self, path: &Path) -> Option<SystemTime> {
+        let flag = match self.stat_flavor() {
+            StatFlavor::Gnu => "-c %Y",
+            StatFlavor::Bsd => "-f %m",
+            StatFlavor::Unsupported => return None,
+        };
+        let cmd = format!("stat {} \"{}\"", flag, path.display());
+        match self.session.as_mut().unwrap().cmd(cmd) {
+            Ok((0, output)) => parser_utils::parse_stat_epoch(&output),
+            _ => None,
+        }
+    }
+
+    /// Fetch the Unix epoch mtime for every entry in `entries` under `dir`
+    /// with a single batched `stat` invocation.
+    ///
+    /// Returns a map from basename to [`SystemTime`]. Entries missing from
+    /// the map should fall back to the `ls`-parsed timestamp.
+    fn mtimes_in_dir(
+        &mut self,
+        dir: &Path,
+        entries: &[&str],
+    ) -> HashMap<String, SystemTime> {
+        if entries.is_empty() {
+            return HashMap::new();
+        }
+        let fmt = match self.stat_flavor() {
+            StatFlavor::Gnu => "-c '%Y %n'",
+            StatFlavor::Bsd => "-f '%m %N'",
+            StatFlavor::Unsupported => return HashMap::new(),
+        };
+        let args: Vec<String> = entries
+            .iter()
+            .map(|name| format!("\"{}\"", dir.join(name).display()))
+            .collect();
+        let cmd = format!("stat {} {}", fmt, args.join(" "));
+        match self.session.as_mut().unwrap().cmd(cmd) {
+            Ok((_, output)) => parser_utils::parse_stat_listing(&output),
+            Err(err) => {
+                warn!("Batched stat failed, falling back to ls timestamps: {err}");
+                HashMap::new()
+            }
+        }
+    }
 }
 
 impl<S> RemoteFs for ScpFs<S>
@@ -281,6 +376,8 @@ where
                 Ok(_) => {
                     // Set session and sftp to none
                     self.session = None;
+                    // Drop cached probe so a fresh connection re-detects.
+                    self.stat_flavor = None;
                     Ok(())
                 }
                 Err(err) => Err(RemoteError::new_ex(RemoteErrorType::ConnectionError, err)),
@@ -371,6 +468,16 @@ where
                         entries.push(entry);
                     }
                 }
+                // Override `ls`-parsed mtimes (which are TZ-ambiguous) with
+                // the server's Unix epoch via `stat`. One batched roundtrip.
+                let names: Vec<String> = entries.iter().map(|e| e.name()).collect();
+                let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+                let mtimes = self.mtimes_in_dir(path.as_path(), &name_refs);
+                for (entry, name) in entries.iter_mut().zip(names.iter()) {
+                    if let Some(t) = mtimes.get(name) {
+                        entry.metadata.modified = Some(*t);
+                    }
+                }
                 debug!(
                     "Found {} out of {} valid file entries",
                     entries.len(),
@@ -410,7 +517,13 @@ where
                     }
                 };
                 match self.parse_ls_output(parent.as_path(), line.as_str().trim()) {
-                    Ok(entry) => Ok(entry),
+                    Ok(mut entry) => {
+                        // Override TZ-ambiguous `ls` mtime with Unix epoch.
+                        if let Some(t) = self.mtime_epoch(path.as_path()) {
+                            entry.metadata.modified = Some(t);
+                        }
+                        Ok(entry)
+                    }
                     Err(_) => Err(RemoteError::new(RemoteErrorType::NoSuchFileOrDirectory)),
                 }
             }

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -2,15 +2,25 @@
 //!
 //! parser utils
 
+use std::collections::HashMap;
+use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use chrono::format::ParseError;
 use chrono::prelude::*;
 
-/// Convert ls syntax time to System Time
-/// ls time has two possible syntax:
-/// 1. if year is current: %b %d %H:%M (e.g. Nov 5 13:46)
-/// 2. else: %b %d %Y (e.g. Nov 5 2019)
+/// Convert `ls` syntax time to [`SystemTime`].
+///
+/// `ls` time has two possible syntaxes:
+/// 1. if year is current: `%b %d %H:%M` (e.g. `Nov 5 13:46`)
+/// 2. else: `%b %d %Y` (e.g. `Nov 5 2019`)
+///
+/// **Note:** this parser is best-effort and timezone-ambiguous. `ls` prints
+/// times in the server's local timezone without a UTC offset, so the returned
+/// [`SystemTime`] is interpreted as if it were UTC. Prefer
+/// [`parse_stat_epoch`] (which consumes the timezone-free epoch emitted by
+/// `stat`) whenever available; this function is retained only as a fallback
+/// for shells/hosts where `stat` is unavailable.
 pub fn parse_lstime(tm: &str, fmt_year: &str, fmt_hours: &str) -> Result<SystemTime, ParseError> {
     let datetime: NaiveDateTime = match NaiveDate::parse_from_str(tm, fmt_year) {
         Ok(date) => {
@@ -35,6 +45,35 @@ pub fn parse_lstime(tm: &str, fmt_year: &str, fmt_hours: &str) -> Result<SystemT
     Ok(sys_time
         .checked_add(Duration::from_secs(datetime.and_utc().timestamp() as u64))
         .unwrap_or(SystemTime::UNIX_EPOCH))
+}
+
+/// Parse the output of `stat -c %Y <path>` (GNU) or `stat -f %m <path>` (BSD).
+///
+/// Both commands emit a single line containing the Unix epoch in seconds.
+/// Returns [`None`] if the output cannot be parsed.
+pub fn parse_stat_epoch(output: &str) -> Option<SystemTime> {
+    let secs: u64 = output.trim().parse().ok()?;
+    SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(secs))
+}
+
+/// Parse the output of `stat -c '%Y %n'` (GNU) or `stat -f '%m %N'` (BSD) for
+/// a set of paths. Each line has the shape `<epoch> <name>`.
+///
+/// Returns a map from basename to [`SystemTime`]. Lines that fail to parse are
+/// silently skipped so that a partial result still enriches the caller.
+pub fn parse_stat_listing(output: &str) -> HashMap<String, SystemTime> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let (epoch, name) = line.trim().split_once(char::is_whitespace)?;
+            let secs: u64 = epoch.trim().parse().ok()?;
+            let time = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(secs))?;
+            let basename = Path::new(name.trim())
+                .file_name()
+                .map(|x| x.to_string_lossy().to_string())?;
+            Some((basename, time))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -90,5 +129,94 @@ mod test {
         assert!(parse_lstime("Oma 31 2018", "%b %d %Y", "%b %d %H:%M").is_err());
         assert!(parse_lstime("Feb 31 2018", "%b %d %Y", "%b %d %H:%M").is_err());
         assert!(parse_lstime("Feb 15 25:32", "%b %d %Y", "%b %d %H:%M").is_err());
+    }
+
+    #[test]
+    fn should_parse_stat_epoch_gnu() {
+        // `stat -c %Y` on Linux emits a bare epoch followed by a newline.
+        let parsed = parse_stat_epoch("1704067200\n").expect("valid epoch");
+        assert_eq!(
+            parsed
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1704067200
+        );
+    }
+
+    #[test]
+    fn should_parse_stat_epoch_bsd() {
+        // `stat -f %m` on macOS/BSD emits a bare epoch without trailing
+        // whitespace when piped.
+        let parsed = parse_stat_epoch("1541376000").expect("valid epoch");
+        assert_eq!(
+            parsed
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1541376000
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_stat_epoch_on_error() {
+        // When stat fails (e.g. command not found or non-zero exit), the
+        // output is empty or contains an error message; parsing must yield
+        // `None` so callers can fall back.
+        assert!(parse_stat_epoch("").is_none());
+        assert!(parse_stat_epoch("stat: cannot stat 'x': No such file").is_none());
+    }
+
+    #[test]
+    fn should_parse_stat_listing_gnu() {
+        let output = "1704067200 /tmp/a.txt\n1541376000 /tmp/b.txt\n";
+        let map = parse_stat_listing(output);
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map.get("a.txt")
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1704067200
+        );
+        assert_eq!(
+            map.get("b.txt")
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1541376000
+        );
+    }
+
+    #[test]
+    fn should_parse_stat_listing_bsd() {
+        // BSD `stat -f '%m %N'` for bare names still emits the same shape.
+        let output = "1704067200 a.txt\n1541376000 b.txt\n";
+        let map = parse_stat_listing(output);
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map.get("a.txt")
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1704067200
+        );
+    }
+
+    #[test]
+    fn should_skip_unparseable_stat_listing_lines() {
+        let output = "1704067200 /tmp/a.txt\nstat: cannot stat '/tmp/missing'\n1541376000 /tmp/b.txt\n";
+        let map = parse_stat_listing(output);
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("a.txt"));
+        assert!(map.contains_key("b.txt"));
+    }
+
+    #[test]
+    fn should_return_empty_stat_listing_on_total_failure() {
+        assert!(parse_stat_listing("").is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `ScpFs` used `parse_lstime` on `ls -l` output, which built a `NaiveDateTime` in the server's local timezone and then called `.and_utc().timestamp()` — effectively relabeling the local time as UTC. Clients rendering via `DateTime<Local>` then displayed a UTC wall clock instead of local. `SftpFs` was unaffected (protocol epoch mtime).
- Probe the remote `stat(1)` flavor once per session (GNU via `stat --version`, else BSD via `stat -f %m /`, else `Unsupported`) and cache on the session.
- `list_dir` runs a single batched `stat -c '%Y %n'` / `stat -f '%m %N'` after `ls -la` and overrides each entry's `modified` by basename.
- `stat` runs a per-path `stat -c %Y` / `stat -f %m` override.
- Falls back to the old `ls`-based parser on hosts where neither flavor works. `parse_lstime` kept and documented as best-effort / TZ-ambiguous.
- Bumps version to `0.8.3` and adds a CHANGELOG entry.

Closes [termscp#416](https://github.com/veeso/termscp/issues/416).

## Test plan

- [x] `cargo lint` (clippy with libssh + libssh2 + russh, `-Dwarnings`)
- [x] `cargo test --all-features --lib` — 258 passed, 0 failed, 1 ignored
- [x] scp integration tests (libssh, libssh2, russh) against the OpenSSH container — 119 passed
- [x] New parser unit tests cover GNU output, BSD output, failure-to-parse, mixed error lines, and empty output