### PR TITLE
fix(russh): close SFTP handles with awaited shutdown to stop handle leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.8.5
+
+### Fixed
+
+- **russh:** SFTP handle leak exhausting the server's open-handle limit
+  > russh-sftp's `File::drop` closes handles via `close_nowait`, which frees
+  > the handle server-side but never decrements the client's open-handle
+  > counter. Reads (one handle per chunk) and writes (one handle per upload)
+  > relied on `Drop`, so the counter climbed monotonically until the
+  > negotiated limit was reached, failing later operations with
+  > `Limit exceeded: Handle limit reached`. Both paths now close handles via
+  > an awaited `shutdown`, which decrements the counter.
+
 ## 0.8.4
 
 Released on 2026-06-08

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remotefs-ssh"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 description = "remotefs SSH client library"

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -540,6 +540,17 @@ impl Seek for SftpFileWriter {
 
 impl remotefs::fs::stream::WriteAndSeek for SftpFileWriter {}
 
+impl Drop for SftpFileWriter {
+    fn drop(&mut self) {
+        use tokio::io::AsyncWriteExt as _;
+        // Close the handle with an awaited close. russh-sftp's `File::drop`
+        // uses `close_nowait`, which never decrements the client's open-handle
+        // counter and would leak a handle per upload until the negotiated limit
+        // is reached ("Handle limit reached").
+        let _ = self.runtime.block_on(self.file.shutdown());
+    }
+}
+
 /// Number of concurrent SFTP file handles used per batch in pipelined reads.
 const SFTP_PIPELINE_DEPTH: usize = 4;
 
@@ -708,7 +719,7 @@ impl PipelinedSftpReader {
         batch_offset: usize,
         batch_len: usize,
     ) -> Result<Vec<u8>, std::io::Error> {
-        use tokio::io::{AsyncReadExt as _, AsyncSeekExt as _};
+        use tokio::io::{AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _};
 
         let chunk_count = batch_len.div_ceil(SFTP_CHUNK_SIZE);
         let mut tasks = Vec::with_capacity(chunk_count);
@@ -717,14 +728,22 @@ impl PipelinedSftpReader {
             let chunk_offset = i * SFTP_CHUNK_SIZE;
             let len = SFTP_CHUNK_SIZE.min(batch_len - chunk_offset);
             let abs_offset = batch_offset + chunk_offset;
-
-            let mut file = session.open(&path).await.map_err(std::io::Error::other)?;
-            file.seek(std::io::SeekFrom::Start(abs_offset as u64))
-                .await?;
+            let session = Arc::clone(&session);
+            let path = path.clone();
 
             tasks.push(tokio::spawn(async move {
+                let mut file = session.open(&path).await.map_err(std::io::Error::other)?;
+                file.seek(std::io::SeekFrom::Start(abs_offset as u64))
+                    .await?;
                 let mut buf = vec![0_u8; len];
-                file.read_exact(&mut buf).await?;
+                let read_res = file.read_exact(&mut buf).await;
+                // Explicitly close the handle with an awaited close. russh-sftp's
+                // `File::drop` uses `close_nowait`, which frees the handle
+                // server-side but never decrements the client's open-handle
+                // counter. Relying on it leaks handles until the negotiated
+                // limit is hit ("Handle limit reached") after many opens.
+                let _ = file.shutdown().await;
+                read_res?;
                 Ok::<(usize, Vec<u8>), std::io::Error>((chunk_offset, buf))
             }));
         }


### PR DESCRIPTION
## Problem

Transferring many files sequentially over the russh SFTP backend fails after some thousands of operations with:

```
Limit exceeded: Handle limit reached
```

## Root cause

russh-sftp 2.3.0 `File::drop` closes handles via `close_nowait`, which frees the handle server-side but **never decrements the client's open-handle counter** (`RawSftpSession.handles`). The client refuses new opens once `handles >= negotiated open_handles` limit.

Two paths relied on `Drop`:

- **Reader** (`PipelinedSftpReader::fetch_batch`) — opens one handle per 4 MiB chunk.
- **Writer** (`SftpFileWriter`) — holds one handle per upload.

The client counter climbed monotonically across the run until the limit was hit.

## Fix

Both paths now close handles via an awaited `shutdown`, which drives `session.close().await` → decrements the counter and marks the file closed (no double-close from `Drop`). The reader additionally moves open+seek into the spawned task.

## Verification

- `cargo lint` (all backends): clean.
- `cargo build --no-default-features --features russh`: ok.

Tests require Docker (`cargo test-all`).