### PR TITLE
fix(russh): fix RSA key auth and wire SSH agent authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixed
 
+- **russh:** public key authentication failing against modern OpenSSH servers
+  > russh maps a `None` hash algorithm to the legacy `ssh-rsa` (SHA-1)
+  > signature, which OpenSSH 8.8+ rejects by default. RSA key authentication
+  > therefore failed with `public key authentication failed` for users on
+  > modern servers (the libssh2/libssh backends negotiate `rsa-sha2-256/512`
+  > transparently). RSA keys now attempt `rsa-sha2-512`, then `rsa-sha2-256`,
+  > then legacy `ssh-rsa`; non-RSA keys are unaffected. The test container was
+  > bumped from OpenSSH 8.6 (which still accepts SHA-1, masking the bug) to
+  > 10.2 so the suite exercises modern signature negotiation.
 - **russh:** SFTP handle leak exhausting the server's open-handle limit
   > russh-sftp's `File::drop` closes handles via `close_nowait`, which frees
   > the handle server-side but never decrements the client's open-handle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **russh:** SSH agent authentication was silently ignored
+  > The russh backend never honored `SshOpts::ssh_agent_identity`, so users
+  > whose keys live only in an ssh-agent (common on macOS) could not
+  > authenticate, unlike the libssh2/libssh backends. The backend now
+  > authenticates via the agent first (agent → key → password), matching the
+  > other backends, requesting `rsa-sha2-256/512` signatures for RSA
+  > identities. Unix only.
 - **russh:** public key authentication failing against modern OpenSSH servers
   > russh maps a `None` hash algorithm to the legacy `ssh-rsa` (SHA-1)
   > signature, which OpenSSH 8.8+ rejects by default. RSA key authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **libssh:** `symlink` created the link with the source and target paths swapped
+  > The libssh backend passed `path`/`target` to `libssh-rs`'s
+  > `symlink(target, dest)` in the wrong order. OpenSSH's older sftp-server
+  > reversed the `SSH_FXP_SYMLINK` arguments, which cancelled the mistake; the
+  > 10.2 server bumped for the russh auth tests no longer does, so symlinks were
+  > created at the wrong path. The arguments are now ordered correctly.
 - **russh:** SSH agent authentication was silently ignored
   > The russh backend never honored `SshOpts::ssh_agent_identity`, so users
   > whose keys live only in an ssh-agent (common on macOS) could not

--- a/src/mock/ssh.rs
+++ b/src/mock/ssh.rs
@@ -8,6 +8,42 @@ use tempfile::NamedTempFile;
 
 use crate::SshKeyStorage;
 
+/// Mock RSA private key (matches the `PUBLIC_KEY` authorized in the test container).
+pub const MOCK_PRIVATE_KEY: &str = r"-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAQEAxKyYUMRCNPlb4ZV1VMofrzApu2l3wgP4Ot9wBvHsw/+RMpcHIbQK
+9iQqAVp8Z+M1fJyPXTKjoJtIzuCLF6Sjo0KI7/tFTh+yPnA5QYNLZOIRZb8skumL4gwHww
+5Z942FDPuUDQ30C2mZR9lr3Cd5pA8S1ZSPTAV9QQHkpgoS8cAL8QC6dp3CJjUC8wzvXh3I
+oN3bTKxCpM10KMEVuWO3lM4Nvr71auB9gzo1sFJ3bwebCZIRH01FROyA/GXRiaOtJFG/9N
+nWWI/iG5AJzArKpLZNHIP+FxV/NoRH0WBXm9Wq5MrBYrD1NQzm+kInpS/2sXk3m1aZWqLm
+HF2NKRXSbQAAA8iI+KSniPikpwAAAAdzc2gtcnNhAAABAQDErJhQxEI0+VvhlXVUyh+vMC
+m7aXfCA/g633AG8ezD/5EylwchtAr2JCoBWnxn4zV8nI9dMqOgm0jO4IsXpKOjQojv+0VO
+H7I+cDlBg0tk4hFlvyyS6YviDAfDDln3jYUM+5QNDfQLaZlH2WvcJ3mkDxLVlI9MBX1BAe
+SmChLxwAvxALp2ncImNQLzDO9eHcig3dtMrEKkzXQowRW5Y7eUzg2+vvVq4H2DOjWwUndv
+B5sJkhEfTUVE7ID8ZdGJo60kUb/02dZYj+IbkAnMCsqktk0cg/4XFX82hEfRYFeb1arkys
+FisPU1DOb6QielL/axeTebVplaouYcXY0pFdJtAAAAAwEAAQAAAP8u3PFuTVV5SfGazwIm
+MgNaux82iOsAT/HWFWecQAkqqrruUw5f+YajH/riV61NE9aq2qNOkcJrgpTWtqpt980GGd
+SHWlgpRWQzfIooEiDk6Pk8RVFZsEykkDlJQSIu2onZjhi5A5ojHgZoGGabDsztSqoyOjPq
+6WPvGYRiDAR3leBMyp1WufBCJqAsC4L8CjPJSmnZhc5a0zXkC9Syz74Fa08tdM7bGhtvP1
+GmzuYxkgxHH2IFeoumUSBHRiTZayGuRUDel6jgEiUMxenaDKXe7FpYzMm9tQZA10Mm4LhK
+5rP9nd2/KRTFRnfZMnKvtIRC9vtlSLBe14qw+4ZCl60AAACAf1kghlO3+HIWplOmk/lCL0
+w75Zz+RdvueL9UuoyNN1QrUEY420LsixgWSeRPby+Rb/hW+XSAZJQHowQ8acFJhU85So7f
+4O4wcDuE4f6hpsW9tTfkCEUdLCQJ7EKLCrod6jIV7hvI6rvXiVucRpeAzdOaq4uzj2cwDd
+tOdYVsnmQAAACBAOVxBsvO/Sr3rZUbNtA6KewZh/09HNGoKNaCeiD7vaSn2UJbbPRByF/o
+Oo5zv8ee8r3882NnmG808XfSn7pPZAzbbTmOaJt0fmyZhivCghSNzV6njW3o0PdnC0fGZQ
+ruVXgkd7RJFbsIiD4dDcF4VCjwWHfTK21EOgJUA5pN6TNvAAAAgQDbcJWRx8Uyhkj2+srb
+3n2Rt6CR7kEl9cw17ItFjMn+pO81/5U2aGw0iLlX7E06TAMQC+dyW/WaxQRey8RRdtbJ1e
+TNKCN34QCWkyuYRHGhcNc0quEDayPw5QWGXlP4BzjfRUcPxY9cCXLe5wDLYsX33HwOAc59
+RorU9FCmS/654wAAABFyb290QDhjNTBmZDRjMzQ1YQECAw==
+-----END OPENSSH PRIVATE KEY-----";
+
+/// Write the mock private key to a temp file and return it.
+pub fn create_key_file() -> NamedTempFile {
+    let mut key = NamedTempFile::new().expect("Failed to create tempfile");
+    writeln!(key, "{MOCK_PRIVATE_KEY}").expect("Failed to write key");
+    key
+}
+
 /// Mock ssh key storage
 pub struct MockSshKeyStorage {
     key: NamedTempFile,
@@ -75,8 +111,8 @@ Compression yes
 ConnectionAttempts  3
 ConnectTimeout      60
 Ciphers             aes128-ctr,aes192-ctr,aes256-ctr
-KexAlgorithms       diffie-hellman-group-exchange-sha256
-MACs                hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
+KexAlgorithms       curve25519-sha256,diffie-hellman-group-exchange-sha256
+MACs                hmac-sha2-512,hmac-sha2-256
 # Hosts
 Host sftp
     HostName    127.0.0.1
@@ -86,6 +122,34 @@ Host scp
     HostName    127.0.0.1
     Port        {port}
     User        sftp
+"##
+    );
+    temp.write_all(config.as_bytes()).unwrap();
+    temp
+}
+
+/// Create an ssh config file that authenticates via `IdentityFile` (no key storage).
+pub fn create_ssh_config_with_identity(port: u16, identity_file: &std::path::Path) -> NamedTempFile {
+    let mut temp = NamedTempFile::new().expect("Failed to create tempfile");
+    let identity = identity_file.display();
+    let config = format!(
+        r##"
+# ssh config
+Compression yes
+Ciphers             aes128-ctr,aes192-ctr,aes256-ctr
+KexAlgorithms       curve25519-sha256,diffie-hellman-group-exchange-sha256
+MACs                hmac-sha2-512,hmac-sha2-256
+# Hosts
+Host sftp
+    HostName     127.0.0.1
+    Port         {port}
+    User         sftp
+    IdentityFile {identity}
+Host scp
+    HostName     127.0.0.1
+    Port         {port}
+    User         sftp
+    IdentityFile {identity}
 "##
     );
     temp.write_all(config.as_bytes()).unwrap();

--- a/src/ssh/backend/libssh.rs
+++ b/src/ssh/backend/libssh.rs
@@ -525,8 +525,13 @@ impl Sftp for LibSshSftp {
     }
 
     fn symlink(&self, path: &Path, target: &Path) -> RemoteResult<()> {
+        // libssh-rs `symlink(target, dest)`: `dest` is the link to create, `target`
+        // is what it points to. The `RemoteFs` trait passes them the other way
+        // (`path` = link, `target` = pointee), so map accordingly. Older OpenSSH
+        // sftp-server reversed the SSH_FXP_SYMLINK args, which masked this; 10.x
+        // no longer does, so the arguments must be ordered correctly here.
         self.inner
-            .symlink(conv_path_to_str(path), conv_path_to_str(target))
+            .symlink(conv_path_to_str(target), conv_path_to_str(path))
             .map_err(|err| {
                 RemoteError::new_ex(
                     RemoteErrorType::FileCreateDenied,

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1058,6 +1058,26 @@ mod test {
     }
 
     #[test]
+    fn should_connect_to_ssh_server_auth_key_from_ssh_config() {
+        use crate::ssh::container::OpensshServer;
+
+        let container = OpensshServer::start();
+        let port = container.port();
+
+        crate::mock::logger();
+        let runtime = test_runtime();
+        // Authenticate purely via the `IdentityFile` directive of the ssh config,
+        // with no key storage configured.
+        let key_file = ssh_mock::create_key_file();
+        let config_file = ssh_mock::create_ssh_config_with_identity(port, key_file.path());
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .runtime(runtime);
+        let session = RusshSession::<NoCheckServerKey>::connect(&opts).unwrap();
+        assert!(session.authenticated().unwrap());
+    }
+
+    #[test]
     fn should_perform_shell_command_on_server() {
         crate::mock::logger();
         let container = crate::ssh::container::OpensshServer::start();

--- a/src/ssh/backend/russh.rs
+++ b/src/ssh/backend/russh.rs
@@ -1078,6 +1078,79 @@ mod test {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn should_connect_to_ssh_server_auth_ssh_agent() {
+        use std::process::Command;
+
+        use crate::SshAgentIdentity;
+        use crate::ssh::container::OpensshServer;
+
+        crate::mock::logger();
+
+        // Spawn a dedicated ssh-agent and load the mock key into it.
+        let agent_out = Command::new("ssh-agent")
+            .arg("-s")
+            .output()
+            .expect("failed to spawn ssh-agent (is openssh installed?)");
+        let agent_stdout = String::from_utf8_lossy(&agent_out.stdout);
+        let auth_sock = parse_agent_var(&agent_stdout, "SSH_AUTH_SOCK")
+            .expect("ssh-agent did not report SSH_AUTH_SOCK");
+        let agent_pid = parse_agent_var(&agent_stdout, "SSH_AGENT_PID")
+            .expect("ssh-agent did not report SSH_AGENT_PID");
+
+        let key_file = ssh_mock::create_key_file();
+        // ssh-add refuses keys with loose permissions.
+        Command::new("chmod")
+            .args(["600", &key_file.path().display().to_string()])
+            .status()
+            .expect("chmod failed");
+        let added = Command::new("ssh-add")
+            .arg(key_file.path())
+            .env("SSH_AUTH_SOCK", &auth_sock)
+            .status()
+            .expect("ssh-add failed to run");
+        assert!(added.success(), "ssh-add could not load the mock key");
+
+        // Point the russh agent client at our agent. No key storage, no password:
+        // authentication must succeed through the agent alone.
+        // SAFETY: tests in this module run single-threaded (`--test-threads=1`).
+        unsafe {
+            std::env::set_var("SSH_AUTH_SOCK", &auth_sock);
+        }
+
+        let container = OpensshServer::start();
+        let port = container.port();
+        let runtime = test_runtime();
+        let config_file = ssh_mock::create_ssh_config(port);
+        let opts = SshOpts::new("sftp")
+            .config_file(config_file.path(), ParseRule::ALLOW_UNKNOWN_FIELDS)
+            .ssh_agent_identity(Some(SshAgentIdentity::All))
+            .runtime(runtime);
+
+        let result = RusshSession::<NoCheckServerKey>::connect(&opts);
+
+        // Tear the agent down regardless of the outcome.
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var("SSH_AUTH_SOCK");
+        }
+        let _ = Command::new("kill").arg(&agent_pid).status();
+
+        let session = result.expect("could not authenticate via ssh agent");
+        assert!(session.authenticated().unwrap());
+    }
+
+    /// Parse a `NAME=value;` assignment from `ssh-agent -s` output.
+    #[cfg(unix)]
+    fn parse_agent_var(output: &str, name: &str) -> Option<String> {
+        let needle = format!("{name}=");
+        let start = output.find(&needle)? + needle.len();
+        let rest = &output[start..];
+        let end = rest.find(';')?;
+        Some(rest[..end].to_string())
+    }
+
+    #[test]
     fn should_perform_shell_command_on_server() {
         crate::mock::logger();
         let container = crate::ssh::container::OpensshServer::start();

--- a/src/ssh/backend/russh/auth.rs
+++ b/src/ssh/backend/russh/auth.rs
@@ -122,27 +122,62 @@ where
             ),
         )
     })?;
+    let private_key = Arc::new(private_key);
 
-    let key_with_hash = russh::keys::PrivateKeyWithHashAlg::new(Arc::new(private_key), None);
+    // For RSA keys, `None` maps to the legacy `ssh-rsa` (SHA-1) signature, which modern
+    // OpenSSH servers reject by default. Try the modern `rsa-sha2-512` / `rsa-sha2-256`
+    // signature algorithms first, falling back to SHA-1 for legacy servers.
+    // For non-RSA keys the hash is ignored, so a single `None` attempt is enough.
+    let hash_algs: &[Option<russh::keys::HashAlg>] = if private_key.algorithm().is_rsa() {
+        &[
+            Some(russh::keys::HashAlg::Sha512),
+            Some(russh::keys::HashAlg::Sha256),
+            None,
+        ]
+    } else {
+        &[None]
+    };
 
-    let auth_result = runtime
-        .block_on(async {
-            session
-                .authenticate_publickey(username, key_with_hash)
-                .await
-        })
-        .map_err(|err| RemoteError::new_ex(RemoteErrorType::AuthenticationFailed, err))?;
+    let mut last_failure = None;
+    for hash_alg in hash_algs {
+        let key_with_hash =
+            russh::keys::PrivateKeyWithHashAlg::new(private_key.clone(), *hash_alg);
 
-    match auth_result {
-        russh::client::AuthResult::Success => Ok(()),
-        russh::client::AuthResult::Failure { .. } => Err(RemoteError::new_ex(
-            RemoteErrorType::AuthenticationFailed,
-            format!(
-                "public key authentication failed for key at '{}'",
-                key_path.display()
-            ),
-        )),
+        let auth_result = runtime
+            .block_on(async {
+                session
+                    .authenticate_publickey(username, key_with_hash)
+                    .await
+            })
+            .map_err(|err| RemoteError::new_ex(RemoteErrorType::AuthenticationFailed, err))?;
+
+        match auth_result {
+            russh::client::AuthResult::Success => return Ok(()),
+            russh::client::AuthResult::Failure {
+                remaining_methods, ..
+            } => {
+                debug!(
+                    "public key authentication with hash {hash_alg:?} failed for key at '{}'; remaining methods: {remaining_methods:?}",
+                    key_path.display()
+                );
+                // If the server no longer offers public key auth, stop retrying hashes.
+                let pubkey_still_offered =
+                    remaining_methods.contains(&russh::MethodKind::PublicKey);
+                last_failure = Some(remaining_methods);
+                if !pubkey_still_offered {
+                    break;
+                }
+            }
+        }
     }
+
+    Err(RemoteError::new_ex(
+        RemoteErrorType::AuthenticationFailed,
+        format!(
+            "public key authentication failed for key at '{}' (remaining methods: {last_failure:?})",
+            key_path.display()
+        ),
+    ))
 }
 
 /// Authenticate with username and password.

--- a/src/ssh/backend/russh/auth.rs
+++ b/src/ssh/backend/russh/auth.rs
@@ -29,6 +29,20 @@ where
 {
     let username = &ssh_config.username;
 
+    // Authentication order mirrors the libssh2/libssh backends: SSH agent first,
+    // then key, then password.
+    if let Some(agent_identity) = opts.ssh_agent_identity.as_ref() {
+        match auth_with_agent(session, runtime, username, agent_identity) {
+            Ok(()) => {
+                info!("Authenticated with ssh agent");
+                return Ok(());
+            }
+            Err(err) => {
+                error!("Could not authenticate with ssh agent: {err}");
+            }
+        }
+    }
+
     // Collect authentication methods in priority order: RSA key, then password
     let mut methods = vec![];
 
@@ -203,4 +217,121 @@ where
             "password authentication failed",
         )),
     }
+}
+
+/// Authenticate with the SSH agent, letting it sign the challenges.
+///
+/// The agent socket is resolved from the `SSH_AUTH_SOCK` environment variable.
+#[cfg(unix)]
+fn auth_with_agent<T>(
+    session: &mut Handle<T>,
+    runtime: &Runtime,
+    username: &str,
+    identity: &crate::SshAgentIdentity,
+) -> RemoteResult<()>
+where
+    T: Handler,
+{
+    use russh::keys::agent::client::AgentClient;
+
+    debug!("Authenticating with username '{username}' via ssh agent");
+
+    runtime.block_on(async {
+        let mut agent = AgentClient::connect_env().await.map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ConnectionError,
+                format!("could not connect to ssh agent: {err}"),
+            )
+        })?;
+
+        let identities = agent.request_identities().await.map_err(|err| {
+            RemoteError::new_ex(
+                RemoteErrorType::ConnectionError,
+                format!("could not list ssh agent identities: {err}"),
+            )
+        })?;
+
+        let mut last_err = None;
+        for agent_identity in identities {
+            let pubkey = agent_identity.public_key().into_owned();
+            let blob = pubkey.to_bytes().unwrap_or_default();
+            if !identity.pubkey_matches(&blob) {
+                continue;
+            }
+            debug!(
+                "Trying to authenticate with ssh agent identity: {}",
+                pubkey.fingerprint(russh::keys::HashAlg::Sha256)
+            );
+
+            // Same SHA-1 caveat as direct key auth: for RSA identities request the
+            // modern rsa-sha2-512/256 signature algorithms before the legacy ssh-rsa.
+            let hash_algs: &[Option<russh::keys::HashAlg>] = if pubkey.algorithm().is_rsa() {
+                &[
+                    Some(russh::keys::HashAlg::Sha512),
+                    Some(russh::keys::HashAlg::Sha256),
+                    None,
+                ]
+            } else {
+                &[None]
+            };
+
+            for hash_alg in hash_algs {
+                match session
+                    .authenticate_publickey_with(username, pubkey.clone(), *hash_alg, &mut agent)
+                    .await
+                {
+                    Ok(russh::client::AuthResult::Success) => return Ok(()),
+                    Ok(russh::client::AuthResult::Failure {
+                        remaining_methods, ..
+                    }) => {
+                        debug!(
+                            "ssh agent auth with hash {hash_alg:?} failed; remaining methods: {remaining_methods:?}"
+                        );
+                        let pubkey_still_offered =
+                            remaining_methods.contains(&russh::MethodKind::PublicKey);
+                        last_err = Some(RemoteError::new_ex(
+                            RemoteErrorType::AuthenticationFailed,
+                            "ssh agent authentication failed",
+                        ));
+                        if !pubkey_still_offered {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        debug!("ssh agent auth signing error: {err}");
+                        last_err = Some(RemoteError::new_ex(
+                            RemoteErrorType::AuthenticationFailed,
+                            format!("ssh agent signing failed: {err}"),
+                        ));
+                        break;
+                    }
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            RemoteError::new_ex(
+                RemoteErrorType::AuthenticationFailed,
+                "ssh agent provided no usable identity",
+            )
+        }))
+    })
+}
+
+/// The SSH agent is only reachable over a Unix socket; on other platforms this is a no-op
+/// that simply reports the agent as unavailable so the remaining methods are tried.
+#[cfg(not(unix))]
+fn auth_with_agent<T>(
+    _session: &mut Handle<T>,
+    _runtime: &Runtime,
+    _username: &str,
+    _identity: &crate::SshAgentIdentity,
+) -> RemoteResult<()>
+where
+    T: Handler,
+{
+    Err(RemoteError::new_ex(
+        RemoteErrorType::AuthenticationFailed,
+        "ssh agent authentication is not supported on this platform for the russh backend",
+    ))
 }

--- a/src/ssh/container.rs
+++ b/src/ssh/container.rs
@@ -13,7 +13,10 @@ impl Image for OpensshServerImage {
     }
 
     fn tag(&self) -> &str {
-        "8.6_p1-r3-ls70"
+        // Use a modern OpenSSH (>= 8.8) which rejects the legacy ssh-rsa (SHA-1)
+        // signature algorithm by default. This ensures the test suite exercises
+        // rsa-sha2-256/512 negotiation, matching what real users run.
+        "10.2_p1-r0-ls226"
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {


### PR DESCRIPTION
## Summary

Fixes two authentication regressions in the russh backend, both reported as ["auth broken"](https://github.com/veeso/termscp/issues/422) after termscp switched to russh.

### 1. RSA public key authentication failed against modern OpenSSH servers

russh maps a `None` hash algorithm to the legacy `ssh-rsa` (SHA-1) signature, which OpenSSH 8.8+ rejects by default. RSA key auth therefore failed with `public key authentication failed` for users on modern servers, while the libssh2/libssh backends negotiate `rsa-sha2-256/512` transparently.

RSA keys now attempt `rsa-sha2-512`, then `rsa-sha2-256`, then legacy `ssh-rsa`, stopping early if the server stops offering publickey auth. Non-RSA keys are unaffected.

This is the exact symptom in termscp#422 (RSA `id_rsa`, macOS).

### 2. SSH agent authentication was silently ignored

The russh backend never read `SshOpts::ssh_agent_identity`, so it skipped the agent entirely. Users whose keys live only in an ssh-agent (common on macOS) could not authenticate, unlike the libssh2/libssh backends.

russh now authenticates via the agent first (**agent → key → password**), connecting over `SSH_AUTH_SOCK`, enumerating identities, filtering by `SshAgentIdentity`, and signing through the agent. RSA identities request `rsa-sha2-512/256`. Agent auth is Unix-only; other platforms fall through to the remaining methods.

## Test container bump

The test container was bumped from OpenSSH 8.6 to 10.2. 8.6 still accepts SHA-1, which **masked the RSA bug** — the existing key-auth test passed against it. The unrealistic single-algo `KexAlgorithms` pin in the test ssh config was modernized accordingly.

## Tests added

- `should_connect_to_ssh_server_auth_key` — now a real reproduction (verified: revert the fix → fails with the issue#422 error; restore → passes).
- `should_connect_to_ssh_server_auth_key_from_ssh_config` — key auth via the ssh config `IdentityFile` directive.
- `should_connect_to_ssh_server_auth_ssh_agent` — spawns an ssh-agent, loads the mock key, authenticates through the agent alone. Wire trace confirms `rsa-sha2-512`.

## Verification

- russh backend 8/8, sftp 34, scp 32 — all pass on OpenSSH 10.2.
- libssh2 + libssh container tests pass on 10.2 (no regression).
- `cargo lint` clean.

## CHANGELOG

Updated under 0.8.5.